### PR TITLE
Transient CO2 per time step

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Gregor Gassner <ggassner@uni-koeln.de", "Johannes Markert <jmarkert@
 version = "0.1.0"
 
 [deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/examples/equilibrium_temperature_co2_transient.jl
+++ b/examples/equilibrium_temperature_co2_transient.jl
@@ -37,3 +37,17 @@ initial_temp = compute_equilibrium!(discretization; verbose = false)
 println("Start evolution of temperature...")
 sol = compute_evolution!(discretization, co2_concentration_at_step, year_start, year_end; verbose=true) 
 println("Is it getting hotter?")
+
+#= 
+# We can compare this data with the annual mean temperature reported by NASA
+# (NASA only reports the temperature anomaly, so we shift the data to match our model's temperature in year 1958)
+using Plots
+temp_array=readdlm(download("https://data.giss.nasa.gov/gistemp/graphs/graph_data/Global_Mean_Estimates_based_on_Land_and_Ocean_Data/graph.txt"); skipstart=5)
+ind = findfirst(temp_array[:,1] .== 1958)
+
+plot!(sol.year_array,sol.mean_temperature_yearly,label="Klimakoffer")
+plot!(sol.year_array,temp_array[ind:end,2].-temp_array[ind,2].+sol.mean_temperature_yearly[1],label="NASA") 
+plot!(sol.year_array,temp_array[ind:end,3].-temp_array[ind,2].+sol.mean_temperature_yearly[1],label="NASA smoothed")
+
+ylabel!("Mean annual temperature [°C]")
+xlabel!("year") =#

--- a/examples/equilibrium_temperature_co2_transient.jl
+++ b/examples/equilibrium_temperature_co2_transient.jl
@@ -1,26 +1,39 @@
+# In this test, we simulate the global temperature from 1958 to 2020 using the 
+# historical data of CO2 concentration in the atmosphere
+# Source: https://climate.nasa.gov/vital-signs/carbon-dioxide/
+
 using Klimakoffer
+using DelimitedFiles
 
-NT = 48 # Number of time-steps per year
+NT = 48 # Number of time-steps per year (must be a multiple of 12)
 
-year_start = 1950
-year_end = 1960
+year_start = 1958
+year_end = 2020
 year_delta = year_end - year_start + 1
 
-co2_concentration_start = 315.0
-co2_concentration_yearly_delta = 1.39
+# Read co2 concentration from NASA's data base
+co2_array=readdlm(download("ftp://aftp.cmdl.noaa.gov/products/trends/co2/co2_mm_mlo.txt"); skipstart=53)
 
-co2_concentration_yearly = zeros(Float64,year_delta)
+co2_concentration_at_step = zeros(Float64,year_delta*NT+1)
+step=0
+total_month = 0
+for years = year_start:year_end
+  for month=1:12
+    global total_month += 1
+    for s=1:NT/12
+      global step += 1
+      co2_concentration_at_step[step] = co2_array[total_month,4]
+    end
+  end
+end
+co2_concentration_at_step[end] = co2_array[total_month + 1,4]
 
 mesh = Mesh()
-model = Model(mesh, NT; co2_concentration = co2_concentration_start)
+model = Model(mesh, NT; co2_concentration = co2_concentration_at_step[1])
 discretization = Discretization(mesh, model, NT)
 
-for years = year_start:year_end
-  iter = years + 1 - year_start
-  co2_concentration_yearly[iter] = co2_concentration_start + co2_concentration_yearly_delta * (iter - 1)
-end
 println("First compute initial temperature distribution when equilibrium is reached")
 initial_temp = compute_equilibrium!(discretization; verbose = false)   
 println("Start evolution of temperature...")
-sol = compute_evolution!(discretization, co2_concentration_yearly, year_start; verbose=true) 
+sol = compute_evolution!(discretization, co2_concentration_at_step, year_start, year_end; verbose=true) 
 println("Is it getting hotter?")

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -66,7 +66,7 @@ end
 
 Compute the evolution of the mean temperature with varying CO2 levels.
 """
-function compute_evolution!(discretization, co2_concentration_yearly, year_start; verbose=true)
+function compute_evolution!(discretization, co2_concentration_at_step, year_start, year_end; verbose=true)
     @unpack mesh, model, low_mat, upp_mat, perm_array, num_steps_year, annual_temperature, rhs, last_rhs  = discretization
     @unpack nx, dof = mesh
     
@@ -74,7 +74,7 @@ function compute_evolution!(discretization, co2_concentration_yearly, year_start
       println("year","  ","Average Temperature")
     end
     
-    max_years = size(co2_concentration_yearly,1)
+    max_years = year_end - year_start + 1
 
     # Allocate output arrays
     year_at_step = zeros(Float64,max_years*num_steps_year+1)
@@ -97,9 +97,9 @@ function compute_evolution!(discretization, co2_concentration_yearly, year_start
     step = 1
 
     for year in 1:max_years
-        set_co2_concentration!(model, co2_concentration_yearly[year])
         average_temperature = 0.0
         for time_step in 1:num_steps_year
+            set_co2_concentration!(model, co2_concentration_at_step[step])
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ EXAMPLES_DIR = joinpath(pathof(Klimakoffer) |> dirname |> dirname, "examples")
     println("")
     @test_nowarn include(joinpath(EXAMPLES_DIR, test_file))
 
-    @test isapprox(sol.mean_temperature_yearly[end], 14.563278065969344, atol=1e-12)
+    @test isapprox(sol.mean_temperature_yearly[end], 15.124711392136751, atol=1e-12)
   end
 
   @testset "Printing types to the REPL" begin


### PR DESCRIPTION
Up to now, Klimakoffer's transient simulations depended on the yearly CO2 concentrations in the atmosphere. This PR makes it possible to specify a different CO2 concentration at each time step.

To test this feature, the transient test (equilibrium_temperature_co2_transient.jl) now uses the historical CO2 data reported (monthly) by NASA.
![image](https://user-images.githubusercontent.com/29205060/134530372-e0671838-ff1a-4096-8ee6-69a58129ed45.png)
![image](https://user-images.githubusercontent.com/29205060/134530410-2f1f3599-51a8-4b38-81dc-d3836bf05a67.png)
