### PR TITLE
 Update LU decomposition routines to use only sparse matrices

### DIFF
--- a/src/Klimakoffer.jl
+++ b/src/Klimakoffer.jl
@@ -1,7 +1,7 @@
 module Klimakoffer
 
 using LinearAlgebra: \, lu
-using SparseArrays: sparse
+using SparseArrays: sparse, spzeros
 using UnPack: @unpack
 using Requires: @require
 

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -1,6 +1,6 @@
 
 struct Discretization{DecompositionType}
-  lu_decomposition::DecompositionType                       # LU decomposition of system matrix
+  lu_decomposition::DecompositionType   # LU decomposition of system matrix
   num_steps_year::Int64                 # Number of time steps per astronomical year
   mesh::Mesh
   model::Model                          # Physical model
@@ -11,7 +11,7 @@ end
 
 
 function Discretization(mesh, model, num_steps_year; run_garbage_collector = true)
-    lu_dec = compute_lu_matrices(mesh, model, num_steps_year)
+    lu_decomposition = compute_lu_matrices(mesh, model, num_steps_year)
 
     if run_garbage_collector
       GC.gc()
@@ -21,7 +21,7 @@ function Discretization(mesh, model, num_steps_year; run_garbage_collector = tru
     rhs     = zeros(mesh.dof)  # TODO: The EBM Fortran code initializes the RHS to zero... Maybe we want to initialize it differently
     last_rhs = zeros(mesh.dof)
 
-    Discretization(lu_dec, num_steps_year, mesh, model, annual_temperature, rhs, last_rhs)
+    Discretization(lu_decomposition, num_steps_year, mesh, model, annual_temperature, rhs, last_rhs)
 end
 
 Base.size(discretization::Discretization) = size(discretization.mesh)
@@ -33,6 +33,6 @@ end
 
 function compute_lu_matrices(mesh, model, num_steps_year)
   mat = compute_matrix(mesh,num_steps_year,model)
-  lu_dec = lu(mat)
-  return lu_dec
+  lu_decomposition = lu(mat)
+  return lu_decomposition
 end

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -1,8 +1,6 @@
 
-struct Discretization{LType, UType, PType}
-  low_mat::LType                        # Lower triangular matrix of LU composition
-  upp_mat::UType                        # Upper triangular matrix of LU composition
-  perm_array::PType                     # Permutation array of LU composition
+struct Discretization{DecType}
+  lu_dec::DecType                       # LU decomposition of system matrix
   num_steps_year::Int64                 # Number of time steps per astronomical year
   mesh::Mesh
   model::Model                          # Physical model
@@ -13,7 +11,7 @@ end
 
 
 function Discretization(mesh, model, num_steps_year; run_garbage_collector = true)
-    low_mat, upp_mat, perm_array = compute_lu_matrices(mesh, model, num_steps_year)
+    lu_dec = compute_lu_matrices(mesh, model, num_steps_year)
 
     if run_garbage_collector
       GC.gc()
@@ -23,7 +21,7 @@ function Discretization(mesh, model, num_steps_year; run_garbage_collector = tru
     rhs     = zeros(mesh.dof)  # TODO: The EBM Fortran code initializes the RHS to zero... Maybe we want to initialize it differently
     last_rhs = zeros(mesh.dof)
 
-    Discretization(low_mat, upp_mat, perm_array, num_steps_year, mesh, model, annual_temperature, rhs, last_rhs)
+    Discretization(lu_dec, num_steps_year, mesh, model, annual_temperature, rhs, last_rhs)
 end
 
 Base.size(discretization::Discretization) = size(discretization.mesh)
@@ -36,8 +34,5 @@ end
 function compute_lu_matrices(mesh, model, num_steps_year)
   mat = compute_matrix(mesh,num_steps_year,model)
   lu_dec = lu(mat)
-  low_mat = sparse(lu_dec.L)
-  upp_mat = sparse(lu_dec.U)
-
-  return low_mat, upp_mat, lu_dec.p
+  return lu_dec
 end

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -1,6 +1,6 @@
 
-struct Discretization{DecType}
-  lu_dec::DecType                       # LU decomposition of system matrix
+struct Discretization{DecompositionType}
+  lu_decomposition::DecompositionType                       # LU decomposition of system matrix
   num_steps_year::Int64                 # Number of time steps per astronomical year
   mesh::Mesh
   model::Model                          # Physical model

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -36,7 +36,7 @@ function compute_equilibrium!(discretization; max_years=100, rel_error=2e-5, ver
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
-            annual_temperature[:, time_step] = lu_dec\rhs
+            annual_temperature[:, time_step] = lu_dec \ rhs
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
             annual_temperature[dof-nx+1:dof, time_step] .= annual_temperature[dof, time_step]
@@ -103,7 +103,7 @@ function compute_evolution!(discretization, co2_concentration_at_step, year_star
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
-            annual_temperature[:, time_step] = lu_dec\rhs
+            annual_temperature[:, time_step] = lu_dec \ rhs
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
             annual_temperature[dof-nx+1:dof, time_step] .= annual_temperature[dof, time_step]

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -20,7 +20,7 @@ end
 * max_years is the maximum number of annual cycles to be computed when searching for equilibrium
 """
 function compute_equilibrium!(discretization; max_years=100, rel_error=2e-5, verbose=true)
-    @unpack mesh, model, lu_dec, num_steps_year, annual_temperature, rhs, last_rhs  = discretization
+    @unpack mesh, model, lu_decomposition, num_steps_year, annual_temperature, rhs, last_rhs  = discretization
     @unpack nx, dof = mesh
     
     average_temperature = average_temperature_old = area_weighted_average(view(annual_temperature, :, num_steps_year), mesh)
@@ -36,7 +36,7 @@ function compute_equilibrium!(discretization; max_years=100, rel_error=2e-5, ver
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
-            annual_temperature[:, time_step] = lu_dec \ rhs
+            annual_temperature[:, time_step] = lu_decomposition \ rhs
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
             annual_temperature[dof-nx+1:dof, time_step] .= annual_temperature[dof, time_step]
@@ -67,7 +67,7 @@ end
 Compute the evolution of the mean temperature with varying CO2 levels.
 """
 function compute_evolution!(discretization, co2_concentration_at_step, year_start, year_end; verbose=true)
-    @unpack mesh, model, lu_dec, num_steps_year, annual_temperature, rhs, last_rhs  = discretization
+    @unpack mesh, model, lu_decomposition, num_steps_year, annual_temperature, rhs, last_rhs  = discretization
     @unpack nx, dof = mesh
     
     if verbose
@@ -103,7 +103,7 @@ function compute_evolution!(discretization, co2_concentration_at_step, year_star
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
-            annual_temperature[:, time_step] = lu_dec \ rhs
+            annual_temperature[:, time_step] = lu_decomposition \ rhs
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
             annual_temperature[dof-nx+1:dof, time_step] .= annual_temperature[dof, time_step]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ EXAMPLES_DIR = joinpath(pathof(Klimakoffer) |> dirname |> dirname, "examples")
     println("")
     @test_nowarn include(joinpath(EXAMPLES_DIR, test_file))
 
-    @test isapprox(GlobTemp, 14.484963368768746, atol=1e-12)
+    @test isapprox(GlobTemp, 14.484963368770806, atol=1e-12)
   end
 
   test_file = "equilibrium_temperature_albedo.jl" 
@@ -22,7 +22,7 @@ EXAMPLES_DIR = joinpath(pathof(Klimakoffer) |> dirname |> dirname, "examples")
     println("")
     @test_nowarn include(joinpath(EXAMPLES_DIR, test_file))
 
-    @test isapprox(GlobTemp, 15.007699256043672, atol=1e-12)
+    @test isapprox(GlobTemp, 15.007699256045628, atol=1e-12)
   end
 
   test_file = "equilibrium_temperature_co2.jl" 
@@ -32,7 +32,7 @@ EXAMPLES_DIR = joinpath(pathof(Klimakoffer) |> dirname |> dirname, "examples")
     println("")
     @test_nowarn include(joinpath(EXAMPLES_DIR, test_file))
 
-    @test isapprox(GlobTemp, 14.495916499275724, atol=1e-12)
+    @test isapprox(GlobTemp, 14.495916499277554, atol=1e-12)
   end
 
   test_file = "transient_temperature_co2.txt"
@@ -42,7 +42,7 @@ EXAMPLES_DIR = joinpath(pathof(Klimakoffer) |> dirname |> dirname, "examples")
     println("")
     @test_nowarn include(joinpath(EXAMPLES_DIR, test_file))
 
-    @test isapprox(sol.mean_temperature_yearly[end], 15.124711386303053, atol=1e-12)
+    @test isapprox(sol.mean_temperature_yearly[end], 15.12471138630498, atol=1e-12)
   end
 
   @testset "Printing types to the REPL" begin


### PR DESCRIPTION
Instead of computing the system matrix in dense format, doing an LU decomposition and then storing it in sparse matrices (as done in `main`), we now initialize and compute the system matrix in sparse format and make use of the sparse routines in `LinearAlgebra`. This simplifies code, and reduces allocations and computation times.

The reference values of the tests had to be changed since the linear solver was changed.

The reduction of allocated memory and time can be easily observed by performing a benchmark analysis on the test `examples/equilibrium_temperature_1950.jl`:
```
using Klimakoffer ; using BenchmarkTools
@benchmark include("examples/equilibrium_temperature_1950.jl")
```

1. Results for `main`
```
BenchmarkTools.Trial: 2 samples with 1 evaluation.
 Range (min … max):  6.730 s …   6.834 s  ┊ GC (min … max): 3.67% … 3.64%
 Time  (median):     6.782 s              ┊ GC (median):    3.65%
 Time  (mean ± σ):   6.782 s ± 73.969 ms  ┊ GC (mean ± σ):  3.65% ± 0.02%

  █                                                       █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  6.73 s         Histogram: frequency by time        6.83 s <

 Memory estimate: 2.47 GiB, allocs estimate: 14439.
```
2. Results for this PR:
```
BenchmarkTools.Trial: 2 samples with 1 evaluation.
 Range (min … max):  3.961 s …  3.970 s  ┊ GC (min … max): 1.69% … 1.68%
 Time  (median):     3.966 s             ┊ GC (median):    1.69%
 Time  (mean ± σ):   3.966 s ± 6.189 ms  ┊ GC (mean ± σ):  1.69% ± 0.01%

  █                                                      █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  3.96 s        Histogram: frequency by time        3.97 s <

 Memory estimate: 1.01 GiB, allocs estimate: 14517.

```
