### PR TITLE
use non-allocating `ldiv!` instead of `\`

### DIFF
--- a/src/Klimakoffer.jl
+++ b/src/Klimakoffer.jl
@@ -1,6 +1,6 @@
 module Klimakoffer
 
-using LinearAlgebra: \, lu
+using LinearAlgebra: lu, ldiv!
 using SparseArrays: sparse, spzeros
 using UnPack: @unpack
 using Requires: @require

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -36,7 +36,7 @@ function compute_equilibrium!(discretization; max_years=100, rel_error=2e-5, ver
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
-            annual_temperature[:, time_step] = lu_decomposition \ rhs
+            ldiv!(view(annual_temperature, :, time_step), lu_decomposition, rhs)
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
             annual_temperature[dof-nx+1:dof, time_step] .= annual_temperature[dof, time_step]
@@ -103,7 +103,7 @@ function compute_evolution!(discretization, co2_concentration_at_step, year_star
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
-            annual_temperature[:, time_step] = lu_decomposition \ rhs
+            ldiv!(view(annual_temperature, :, time_step), lu_decomposition, rhs)
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
             annual_temperature[dof-nx+1:dof, time_step] .= annual_temperature[dof, time_step]

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -36,6 +36,7 @@ function compute_equilibrium!(discretization; max_years=100, rel_error=2e-5, ver
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
+            # Use in-place operation `ldiv!` instead of `\` to avoid allocations
             ldiv!(view(annual_temperature, :, time_step), lu_decomposition, rhs)
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]
@@ -103,6 +104,7 @@ function compute_evolution!(discretization, co2_concentration_at_step, year_star
             old_time_step = (time_step == 1) ? num_steps_year : time_step - 1
             update_rhs!(rhs, mesh, num_steps_year, time_step, view(annual_temperature, :, old_time_step), model, last_rhs)
                         
+            # Use in-place operation `ldiv!` instead of `\` to avoid allocations
             ldiv!(view(annual_temperature, :, time_step), lu_decomposition, rhs)
 
             annual_temperature[1:nx, time_step] .= annual_temperature[1, time_step]


### PR DESCRIPTION
I just noticed that you use `\` with a factorization (#19). Using `ldiv!` instead reduces allocations. The performance will likely not be very different unless GC becomes a bottleneck for you.